### PR TITLE
Three UX updates

### DIFF
--- a/CmdPal.Ext.Spotify/Commands/PausePlaybackCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/PausePlaybackCommand.cs
@@ -1,4 +1,6 @@
-﻿using SpotifyAPI.Web;
+﻿using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using SpotifyAPI.Web;
 using System.Threading.Tasks;
 
 namespace CmdPal.Ext.Spotify.Commands;
@@ -7,6 +9,8 @@ internal sealed partial class PausePlaybackCommand : PlayerCommand<PlayerPausePl
 {
     public PausePlaybackCommand(SpotifyClient spotifyClient) : base(spotifyClient, new())
     {
+        Name = Resources.ResultPausePlaybackTitle;
+        Icon = Icons.Pause;
     }
 
     protected override async Task InvokeAsync(IPlayerClient player, PlayerPausePlaybackRequest requestParams)

--- a/CmdPal.Ext.Spotify/Commands/ResumePlaybackCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/ResumePlaybackCommand.cs
@@ -1,4 +1,6 @@
-﻿using SpotifyAPI.Web;
+﻿using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using SpotifyAPI.Web;
 using System.Threading.Tasks;
 
 namespace CmdPal.Ext.Spotify.Commands;
@@ -7,9 +9,11 @@ internal sealed partial class ResumePlaybackCommand : PlayerCommand<PlayerResume
 {
     public ResumePlaybackCommand(SpotifyClient spotifyClient, PlayerResumePlaybackRequest requestParams = null) : base(spotifyClient, requestParams ?? new())
     {
+        Name = requestParams == null ? Resources.ResultResumePlaybackTitle : Resources.ResultPlayName;
+        Icon = Icons.Play;
     }
 
-    public ResumePlaybackCommand(SpotifyClient spotifyClient, string contextUri) : base(spotifyClient, new PlayerResumePlaybackRequest { ContextUri = contextUri })
+    public ResumePlaybackCommand(SpotifyClient spotifyClient, string contextUri) : this(spotifyClient, new PlayerResumePlaybackRequest { ContextUri = contextUri })
     {
     }
 

--- a/CmdPal.Ext.Spotify/Commands/SetRepeatCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/SetRepeatCommand.cs
@@ -1,4 +1,6 @@
-﻿using SpotifyAPI.Web;
+﻿using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using SpotifyAPI.Web;
 using System.Threading.Tasks;
 
 namespace CmdPal.Ext.Spotify.Commands;
@@ -7,6 +9,13 @@ internal sealed partial class SetRepeatCommand : PlayerCommand<PlayerSetRepeatRe
 {
     public SetRepeatCommand(SpotifyClient spotifyClient, PlayerSetRepeatRequest requestParams) : base(spotifyClient, requestParams)
     {
+        Name = requestParams.StateParam switch
+        {
+            PlayerSetRepeatRequest.State.Off => Resources.ResultSetRepeatOffTitle,
+            PlayerSetRepeatRequest.State.Context => Resources.ResultSetRepeatContextTitle,
+            PlayerSetRepeatRequest.State.Track => Resources.ResultSetRepeatTrackTitle,
+        };
+        Icon = Icons.Repeat;
     }
 
     protected override async Task InvokeAsync(IPlayerClient player, PlayerSetRepeatRequest requestParams)

--- a/CmdPal.Ext.Spotify/Commands/SetShuffleCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/SetShuffleCommand.cs
@@ -1,4 +1,6 @@
-﻿using SpotifyAPI.Web;
+﻿using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using SpotifyAPI.Web;
 using System.Threading.Tasks;
 
 namespace CmdPal.Ext.Spotify.Commands;
@@ -7,6 +9,12 @@ internal sealed partial class SetShuffleCommand : PlayerCommand<PlayerShuffleReq
 {
     public SetShuffleCommand(SpotifyClient spotifyClient, PlayerShuffleRequest requestParams) : base(spotifyClient, requestParams)
     {
+        Name = requestParams.State switch
+        {
+            true => Resources.ResultTurnOnShuffleTitle,
+            false => Resources.ResultTurnOffShuffleTitle,
+        };
+        Icon = Icons.Shuffle;
     }
 
     protected override async Task InvokeAsync(IPlayerClient player, PlayerShuffleRequest requestParams)

--- a/CmdPal.Ext.Spotify/Commands/SkipNextCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/SkipNextCommand.cs
@@ -1,4 +1,6 @@
-﻿using SpotifyAPI.Web;
+﻿using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using SpotifyAPI.Web;
 using System.Threading.Tasks;
 
 namespace CmdPal.Ext.Spotify.Commands;
@@ -7,6 +9,8 @@ internal sealed partial class SkipNextCommand : PlayerCommand<PlayerSkipNextRequ
 {
     public SkipNextCommand(SpotifyClient spotifyClient) : base(spotifyClient, new())
     {
+        Name = Resources.ResultNextTrackTitle;
+        Icon = Icons.Next;
     }
 
     protected override async Task InvokeAsync(IPlayerClient player, PlayerSkipNextRequest requestParams)

--- a/CmdPal.Ext.Spotify/Commands/SkipPreviousCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/SkipPreviousCommand.cs
@@ -1,4 +1,6 @@
-﻿using SpotifyAPI.Web;
+﻿using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using SpotifyAPI.Web;
 using System.Threading.Tasks;
 
 namespace CmdPal.Ext.Spotify.Commands;
@@ -7,6 +9,8 @@ internal sealed partial class SkipPreviousCommand : PlayerCommand<PlayerSkipPrev
 {
     public SkipPreviousCommand(SpotifyClient spotifyClient) : base(spotifyClient, new())
     {
+        Name = Resources.ResultPreviousTrackTitle;
+        Icon = Icons.Previous;
     }
 
     protected override async Task InvokeAsync(IPlayerClient player, PlayerSkipPreviousRequest requestParams)

--- a/CmdPal.Ext.Spotify/Commands/TogglePlaybackCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/TogglePlaybackCommand.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CommandPalette.Extensions.Toolkit;
+﻿using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using SpotifyAPI.Web;
 using System.Threading.Tasks;
 
@@ -8,6 +10,8 @@ internal sealed partial class TogglePlaybackCommand : PlayerCommand<PlayerResume
 {
     public TogglePlaybackCommand(SpotifyClient spotifyClient) : base(spotifyClient, new())
     {
+        Name = Resources.ResultTogglePlaybackTitle;
+        Icon = Icons.PlayPause;
     }
 
     protected override async Task InvokeAsync(IPlayerClient player, PlayerResumePlaybackRequest requestParams)

--- a/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
+++ b/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
@@ -24,7 +24,7 @@ internal sealed partial class SpotifyListPage : DynamicListPage
 
     public SpotifyListPage(SettingsManager settingsManager)
     {
-        Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.png");
+        Icon = Icons.Spotify;
         Title = Resources.ExtensionDisplayName;
         Name = Resources.ExtensionDisplayName;
 

--- a/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
+++ b/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
@@ -112,57 +112,22 @@ internal sealed partial class SpotifyListPage : DynamicListPage
 
     private List<ListItem> GetPlayertItems()
     {
+        return GetPlaybackCommands().Select(command => new ListItem(command)).ToList();
+    }
+
+    public List<Command> GetPlaybackCommands()
+    {
         return [
-            new ListItem(new TogglePlaybackCommand(_spotifyClient))
-            {
-                Title = Resources.ResultTogglePlaybackTitle,
-                Icon = Icons.PlayPause,
-            },
-            new ListItem(new PausePlaybackCommand(_spotifyClient))
-            {
-                Title = Resources.ResultPausePlaybackTitle,
-                Icon = Icons.Pause,
-            },
-            new ListItem(new ResumePlaybackCommand(_spotifyClient))
-            {
-                Title = Resources.ResultResumePlaybackTitle,
-                Icon = Icons.Play,
-            },
-            new ListItem(new SkipNextCommand(_spotifyClient))
-            {
-                Title = Resources.ResultNextTrackTitle,
-                Icon = Icons.Next,
-            },
-            new ListItem(new SkipPreviousCommand(_spotifyClient))
-            {
-                Title = Resources.ResultPreviousTrackTitle,
-                Icon = Icons.Previous,
-            },
-            new ListItem(new SetShuffleCommand(_spotifyClient, new(true)))
-            {
-                Title = Resources.ResultTurnOnShuffleTitle,
-                Icon = Icons.Shuffle,
-            },
-            new ListItem(new SetShuffleCommand(_spotifyClient, new(false)))
-            {
-                Title = Resources.ResultTurnOffShuffleTitle,
-                Icon = Icons.Shuffle,
-            },
-            new ListItem(new SetRepeatCommand(_spotifyClient, new(PlayerSetRepeatRequest.State.Track)))
-            {
-                Title = Resources.ResultSetRepeatTrackTitle,
-                Icon = Icons.Repeat,
-            },
-            new ListItem(new SetRepeatCommand(_spotifyClient, new(PlayerSetRepeatRequest.State.Context)))
-            {
-                Title = Resources.ResultSetRepeatContextTitle,
-                Icon = Icons.Repeat,
-            },
-            new ListItem(new SetRepeatCommand(_spotifyClient, new(PlayerSetRepeatRequest.State.Off)))
-            {
-                Title = Resources.ResultSetRepeatOffTitle,
-                Icon = Icons.Repeat,
-            },
+            new TogglePlaybackCommand(_spotifyClient),
+            new PausePlaybackCommand(_spotifyClient),
+            new ResumePlaybackCommand(_spotifyClient),
+            new SkipNextCommand(_spotifyClient),
+            new SkipPreviousCommand(_spotifyClient),
+            new SetShuffleCommand(_spotifyClient, new(true)),
+            new SetShuffleCommand(_spotifyClient, new(false)),
+            new SetRepeatCommand(_spotifyClient, new(PlayerSetRepeatRequest.State.Track)),
+            new SetRepeatCommand(_spotifyClient, new(PlayerSetRepeatRequest.State.Context)),
+            new SetRepeatCommand(_spotifyClient, new(PlayerSetRepeatRequest.State.Off)),
         ];
     }
 
@@ -182,7 +147,7 @@ internal sealed partial class SpotifyListPage : DynamicListPage
                 new ListItem(new ResumePlaybackCommand(_spotifyClient, new PlayerResumePlaybackRequest() { Uris = [track.Uri] }))
                 {
                     Title = track.Name,
-                    Subtitle = $"{Resources.ResultSongSubTitle}{(track.Explicit ? $" • {Resources.ResultSongExplicitSubTitle}" : "")} • {Resources.ResultSongBySubTitle} {string.Join(", ", track.Artists.Select(x => x.Name))}",
+                    Subtitle = $"{Resources.ResultSongSubTitle}{(track.Explicit ? $" ï¿½ {Resources.ResultSongExplicitSubTitle}" : "")} ï¿½ {Resources.ResultSongBySubTitle} {string.Join(", ", track.Artists.Select(x => x.Name))}",
                     Icon = new IconInfo(track.Album.Images.OrderBy(x => x.Width * x.Height).FirstOrDefault()?.Url),
                 })
             );

--- a/CmdPal.Ext.Spotify/Properties/Resources.Designer.cs
+++ b/CmdPal.Ext.Spotify/Properties/Resources.Designer.cs
@@ -70,6 +70,42 @@ namespace CmdPal.Ext.Spotify.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search for songs, albums, artists, playlists....
+        /// </summary>
+        internal static string EmptyContentSubtitle {
+            get {
+                return ResourceManager.GetString("EmptyContentSubtitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Search Spotify.
+        /// </summary>
+        internal static string EmptyContentTitle {
+            get {
+                return ResourceManager.GetString("EmptyContentTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Error fetching from API.
+        /// </summary>
+        internal static string EmptyErrorTitle {
+            get {
+                return ResourceManager.GetString("EmptyErrorTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to No results found.
+        /// </summary>
+        internal static string EmptyResultsTitle {
+            get {
+                return ResourceManager.GetString("EmptyResultsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search through and control Spotify..
         /// </summary>
         internal static string ExtensionDescription {
@@ -93,6 +129,15 @@ namespace CmdPal.Ext.Spotify.Properties {
         internal static string ExtensionSettingClientIdDescription {
             get {
                 return ResourceManager.GetString("ExtensionSettingClientIdDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search Spotify.
+        /// </summary>
+        internal static string PageTitle {
+            get {
+                return ResourceManager.GetString("PageTitle", resourceCulture);
             }
         }
         

--- a/CmdPal.Ext.Spotify/Properties/Resources.Designer.cs
+++ b/CmdPal.Ext.Spotify/Properties/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace CmdPal.Ext.Spotify.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Play.
+        /// </summary>
+        internal static string ResultPlayName {
+            get {
+                return ResourceManager.GetString("ResultPlayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Previous track.
         /// </summary>
         internal static string ResultPreviousTrackTitle {

--- a/CmdPal.Ext.Spotify/Properties/Resources.resx
+++ b/CmdPal.Ext.Spotify/Properties/Resources.resx
@@ -159,6 +159,9 @@
   <data name="ResultPausePlaybackTitle" xml:space="preserve">
     <value>Pause playback</value>
   </data>
+  <data name="ResultPlayName" xml:space="preserve">
+    <value>Play</value>
+  </data>
   <data name="ResultResumePlaybackTitle" xml:space="preserve">
     <value>Resume playback</value>
   </data>

--- a/CmdPal.Ext.Spotify/SpotifyCommandsProvider.cs
+++ b/CmdPal.Ext.Spotify/SpotifyCommandsProvider.cs
@@ -21,7 +21,7 @@ public partial class SpotifyCommandsProvider : CommandProvider
 
         _command = new CommandItem(_spotifyExtensionPage)
         {
-            Title = DisplayName,
+            Title = Resources.PageTitle,
             Subtitle = Resources.ExtensionDescription,
             Icon = Icons.Spotify,
             MoreCommands = [new CommandContextItem(Settings.SettingsPage)]

--- a/CmdPal.Ext.Spotify/SpotifyCommandsProvider.cs
+++ b/CmdPal.Ext.Spotify/SpotifyCommandsProvider.cs
@@ -16,7 +16,7 @@ public partial class SpotifyCommandsProvider : CommandProvider
     {
         DisplayName = Resources.ExtensionDisplayName;
         Id = "Spotify";
-        Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.png");
+        Icon = Icons.Spotify;
         Settings = _settingsManager.Settings;
 
         _command = new CommandItem(_spotifyExtensionPage)


### PR DESCRIPTION
I tried to make this into three smaller commits, but then the last one ended up being a lot bigger. 

* 4185eb8846cfc846656452091bfe1fcc8ecb804e: This just fixes the icon on the page, so that the spotify logo shows up on the page. 
* db85f650fdbb46d6bb4fae358facbd7a8d8fff97: Moves the text of the playback commands from the `ListItem`s into the `Command`s themselves. That'll make the text of the command show up on the buttons at the bottom right
* 5f29a95cabf041fde2e1686417291328834ae4f1: This replaces a bunch of the cases where one `ListItem` would be used to display a message with `EmptyContent`. (this is poorly documented). This gives the text a bigger treatment, to clearly indicate that the message is different than just a list item. 

I hope this makes it a bit clearer that you can also search Spotify too - that wasn't immediately clear to me when I first loaded this extension. 

![cmdpal-spotify-nits](https://github.com/user-attachments/assets/9b9e1563-eebc-47e8-83b2-4a48164ac3ab)

The localization I might have not done right - I have a much newer version of the loc tools locally, so I had to make these updates manually. 

(this is also probably my favorite new extension so far. Most definitely in the top three)