### PR TITLE
Add context item to add songs to queue

### DIFF
--- a/CmdPal.Ext.Spotify/Commands/AddToQueueCommand.cs
+++ b/CmdPal.Ext.Spotify/Commands/AddToQueueCommand.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using CmdPal.Ext.Spotify.Helpers;
+using CmdPal.Ext.Spotify.Properties;
+using SpotifyAPI.Web;
+
+namespace CmdPal.Ext.Spotify.Commands;
+
+internal sealed partial class AddToQueueCommand : PlayerCommand<PlayerAddToQueueRequest>
+{
+    public AddToQueueCommand(SpotifyClient spotifyClient, PlayerAddToQueueRequest requestParams) : base(spotifyClient, requestParams)
+    {
+        Name = Resources.ContextMenuResultAddToQueueTitle;
+        Icon = Icons.Play;
+    }
+
+    public AddToQueueCommand(SpotifyClient spotifyClient, string uri) : this(spotifyClient, new PlayerAddToQueueRequest(uri))
+    {
+    }
+
+    protected override async Task InvokeAsync(IPlayerClient player, PlayerAddToQueueRequest requestParams)
+    {
+        await player.AddToQueue(requestParams);
+    }
+}

--- a/CmdPal.Ext.Spotify/Helpers/ContextCommands.cs
+++ b/CmdPal.Ext.Spotify/Helpers/ContextCommands.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CmdPal.Ext.Spotify.Helpers;
+
+public static class ContextCommands
+{
+    public static CommandContextItem ToContextCommand(this ICommand command)
+    {
+        return new CommandContextItem(command);
+    }
+    
+    // This won't work yet. The feature on the sdk side is not yet available through nuget
+    public static CommandContextItem ToContextCommand(this ICommand command, KeyChord requestedShortcut)
+    {
+        return new CommandContextItem(command) { RequestedShortcut = requestedShortcut };
+    }
+}

--- a/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
+++ b/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
@@ -172,6 +172,7 @@ internal sealed partial class SpotifyListPage : DynamicListPage
                     Title = track.Name,
                     Subtitle = $"{Resources.ResultSongSubTitle}{(track.Explicit ? $" • {Resources.ResultSongExplicitSubTitle}" : "")} • {Resources.ResultSongBySubTitle} {string.Join(", ", track.Artists.Select(x => x.Name))}",
                     Icon = new IconInfo(track.Album.Images.OrderBy(x => x.Width * x.Height).FirstOrDefault()?.Url),
+                    MoreCommands = [new AddToQueueCommand(_spotifyClient, track.Uri).ToContextCommand()],
                 })
             );
 

--- a/CmdPal.Ext.Spotify/Properties/Resources.resx
+++ b/CmdPal.Ext.Spotify/Properties/Resources.resx
@@ -184,7 +184,7 @@
     <value>Set repeat to off</value>
   </data>
   <data name="ContextMenuResultAddToQueueTitle" xml:space="preserve">
-    <value>Add to queue (Shift+Enter)</value>
+    <value>Add to queue</value>
   </data>
   <data name="ResultPlaylistSubTitle" xml:space="preserve">
     <value>Playlist</value>

--- a/CmdPal.Ext.Spotify/Properties/Resources.zh-CN.resx
+++ b/CmdPal.Ext.Spotify/Properties/Resources.zh-CN.resx
@@ -184,7 +184,7 @@
     <value>关闭重复播放</value>
   </data>
   <data name="ContextMenuResultAddToQueueTitle" xml:space="preserve">
-    <value>添加到队列 (Shift+Enter)</value>
+    <value>添加到队列</value>
   </data>
   <data name="ResultPlaylistSubTitle" xml:space="preserve">
     <value>播放列表</value>


### PR DESCRIPTION
Adds the ability to add songs to queue instead of playing them directly, addressing #8 

When selecting a song from the search function, the user has a new option of using Ctrl+Enter to queue the selected song instead of playing it immediately.

I've also removed the hardcoded "Shift + Enter" from localization resource manager because:
1. It's redundant, command palette shows the keys next to each option anyways
2. The first context command can seemingly not be remapped to a new shortcut, it must always be Ctrl+Enter

A workaround to 2. above could be to add the same command twice, with the second command properly having the Shift+Enter shortcut, although this may create confusion with having two identical commands, so I think sacrificing some possible muscle memory from the older run-based plugin is worth it here.

I was unable to run localization tools on my device, although my changes are minimal in that regard and I used existing entries so I don't foresee an issue there.

One follow-up item to this PR is to allow queueing albums. The Spotify queue API can only take track references, so it's not as straightforward.

![Queueing a song](https://github.com/user-attachments/assets/371e36a8-4699-4b5e-add6-8509cd5cccd2)