### PR TITLE
Functionality: Adds result filtering

### DIFF
--- a/CmdPal.Ext.Spotify/Helpers/SettingsManager.cs
+++ b/CmdPal.Ext.Spotify/Helpers/SettingsManager.cs
@@ -27,11 +27,21 @@ public class SettingsManager : JsonSettingsManager
 
     public string ClientId => _clientId.Value;
 
+    private readonly TextSetting _filterWildcard = new(
+        Namespaced(nameof(FilterWildcard)),
+        Resources.ExtensionSettingFilterWildcard,
+        Resources.ExtensionSettingFilterWildcardDescription,
+        "/"
+    );
+
+    public string FilterWildcard => _filterWildcard.Value;
+
     public SettingsManager()
     {
         FilePath = SettingsJsonPath();
 
         Settings.Add(_clientId);
+        Settings.Add(_filterWildcard);
 
         LoadSettings();
 

--- a/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
+++ b/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
@@ -208,7 +208,7 @@ internal sealed partial class SpotifyListPage : DynamicListPage
                 })
             );
 
-        if (searchResponse.Playlists.Items != null)
+        if (searchResponse.Playlists != null && searchResponse.Playlists.Items != null)
             results.AddRange(searchResponse.Playlists.Items.Where(playlist => playlist != null).Select(playlist =>
                 new ListItem(new ResumePlaybackCommand(_spotifyClient, playlist.Uri))
                 {

--- a/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
+++ b/CmdPal.Ext.Spotify/Pages/SpotifListPage.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace CmdPal.Ext.Spotify.Pages;
 
@@ -21,6 +22,8 @@ internal sealed partial class SpotifyListPage : DynamicListPage
     private string _credentialsPath;
     private SpotifyClient _spotifyClient;
     private Timer _debounceTimer;
+    private List<string> _neutralTypeFilters = new(["album", "artist", "playlist", "track"]);
+    private List<string> _localTypeFilters = new();
 
     public SpotifyListPage(SettingsManager settingsManager)
     {
@@ -30,6 +33,8 @@ internal sealed partial class SpotifyListPage : DynamicListPage
 
         _settingsManager = settingsManager;
         _settingsManager.Settings.SettingsChanged += (_, _) => SearchAsync(SearchText);
+
+        _localTypeFilters = [Resources.SearchTypeAlbum, Resources.SearchTypeArtist, Resources.SearchTypePlaylist, Resources.SearchTypeTrack];
 
         var appDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CmdPal.Ext.Spotify");
         _credentialsPath = Path.Combine(appDataPath, "credentials.json");
@@ -99,15 +104,21 @@ internal sealed partial class SpotifyListPage : DynamicListPage
         if (_spotifyClient == null)
             _spotifyClient = await GetSpotifyClientAsync(clientId);
 
+        var searchFilter = ApplySearchFilter(ref search);
+
         if (string.IsNullOrEmpty(search.Trim()))
         {
-            EmptyContent = _defaultEmptyContent;
+            if (searchFilter != SearchRequest.Types.All) EmptyContent = new CommandItem()
+            {
+                Title = Resources.EmptyFilteredResultsTitle,
+            };
+            else EmptyContent = _defaultEmptyContent;
             return [];
         }
 
         try
         {
-            var results = await GetSearchItemsAsync(search);
+            var results = await GetSearchItemsAsync(search, searchFilter);
             if (results.Count == 0)
                 EmptyContent = new CommandItem()
                 {
@@ -154,18 +165,18 @@ internal sealed partial class SpotifyListPage : DynamicListPage
         ];
     }
 
-    private async Task<List<ListItem>> GetSearchItemsAsync(string search)
+    private async Task<List<ListItem>> GetSearchItemsAsync(string search, SearchRequest.Types searchParams)
     {
         var results = new List<ListItem>();
 
-        var searchRequest = new SearchRequest(SearchRequest.Types.All, search)
+        var searchRequest = new SearchRequest(searchParams, search)
         {
             Limit = 5
         };
 
         var searchResponse = await _spotifyClient.Search.Item(searchRequest);
 
-        if (searchResponse.Tracks.Items != null)
+        if (searchResponse.Tracks != null && searchResponse.Tracks.Items != null)
             results.AddRange(searchResponse.Tracks.Items.Where(track => track != null).Select(track =>
                 new ListItem(new ResumePlaybackCommand(_spotifyClient, new PlayerResumePlaybackRequest() { Uris = [track.Uri] }))
                 {
@@ -176,7 +187,7 @@ internal sealed partial class SpotifyListPage : DynamicListPage
                 })
             );
 
-        if (searchResponse.Albums.Items != null)
+        if (searchResponse.Albums != null && searchResponse.Albums.Items != null)
             results.AddRange(searchResponse.Albums.Items.Where(album => album != null).Select(album =>
                 new ListItem(new ResumePlaybackCommand(_spotifyClient, album.Uri))
                 {
@@ -187,7 +198,7 @@ internal sealed partial class SpotifyListPage : DynamicListPage
             );
 
 
-        if (searchResponse.Artists.Items != null)
+        if (searchResponse.Artists != null && searchResponse.Artists.Items != null)
             results.AddRange(searchResponse.Artists.Items.Where(artist => artist != null).Select(artist =>
                 new ListItem(new ResumePlaybackCommand(_spotifyClient, artist.Uri))
                 {
@@ -208,5 +219,33 @@ internal sealed partial class SpotifyListPage : DynamicListPage
             );
 
         return results;
+    }
+
+    private SearchRequest.Types ApplySearchFilter(ref string search)
+    {
+        var wildcard = _settingsManager.FilterWildcard;
+        /* 
+         * This pattern filters results using the 'types' parameter.
+         * Allowed values: "album", "artist", "playlist", "track", "show", "episode", "audiobook"
+        */
+        var typePattern = $"{wildcard}({String.Join("|", _localTypeFilters)})";
+
+        var searchFilter = SearchRequest.Types.All;
+
+        if (Regex.IsMatch(search, typePattern))
+        {
+            var matches = Regex.Matches(search, typePattern);
+            var types = new List<string>();
+            foreach (var match in matches)
+            {
+                var value = match.ToString().Substring(1);
+                var index = _localTypeFilters.FindIndex((e) => e == value);
+                types.Add(_neutralTypeFilters[index]);
+            }
+            bool test = Enum.TryParse(String.Join(", ", types), true, out searchFilter);
+            search = Regex.Replace(search, typePattern, "").Trim();
+        }
+
+        return searchFilter;
     }
 }

--- a/CmdPal.Ext.Spotify/Properties/Resources.Designer.cs
+++ b/CmdPal.Ext.Spotify/Properties/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace CmdPal.Ext.Spotify.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No item found (filter applied)..
+        /// </summary>
+        internal static string EmptyFilteredResultsTitle {
+            get {
+                return ResourceManager.GetString("EmptyFilteredResultsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No item found..
         /// </summary>
         internal static string EmptyResultsTitle {
@@ -111,6 +120,24 @@ namespace CmdPal.Ext.Spotify.Properties {
         internal static string ExtensionSettingClientIdDescription {
             get {
                 return ResourceManager.GetString("ExtensionSettingClientIdDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter Wildcard.
+        /// </summary>
+        internal static string ExtensionSettingFilterWildcard {
+            get {
+                return ResourceManager.GetString("ExtensionSettingFilterWildcard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter wildcard character used to prepend a filter, e.g. /album or !album.
+        /// </summary>
+        internal static string ExtensionSettingFilterWildcardDescription {
+            get {
+                return ResourceManager.GetString("ExtensionSettingFilterWildcardDescription", resourceCulture);
             }
         }
         
@@ -300,6 +327,69 @@ namespace CmdPal.Ext.Spotify.Properties {
         internal static string ResultTurnOnShuffleTitle {
             get {
                 return ResourceManager.GetString("ResultTurnOnShuffleTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to album.
+        /// </summary>
+        internal static string SearchTypeAlbum {
+            get {
+                return ResourceManager.GetString("SearchTypeAlbum", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to artist.
+        /// </summary>
+        internal static string SearchTypeArtist {
+            get {
+                return ResourceManager.GetString("SearchTypeArtist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to audiobook.
+        /// </summary>
+        internal static string SearchTypeAudiobook {
+            get {
+                return ResourceManager.GetString("SearchTypeAudiobook", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to episode.
+        /// </summary>
+        internal static string SearchTypeEpisode {
+            get {
+                return ResourceManager.GetString("SearchTypeEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to playlist.
+        /// </summary>
+        internal static string SearchTypePlaylist {
+            get {
+                return ResourceManager.GetString("SearchTypePlaylist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to show.
+        /// </summary>
+        internal static string SearchTypeShow {
+            get {
+                return ResourceManager.GetString("SearchTypeShow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to track.
+        /// </summary>
+        internal static string SearchTypeTrack {
+            get {
+                return ResourceManager.GetString("SearchTypeTrack", resourceCulture);
             }
         }
     }

--- a/CmdPal.Ext.Spotify/Properties/Resources.resx
+++ b/CmdPal.Ext.Spotify/Properties/Resources.resx
@@ -198,4 +198,44 @@
   <data name="EmptyResultsTitle" xml:space="preserve">
     <value>No item found.</value>
   </data>
+  <data name="ExtensionSettingFilterWildcardDescription" xml:space="preserve">
+    <value>Filter wildcard character used to prepend a filter, e.g. /album or !album</value>
+  </data>
+  <data name="ExtensionSettingFilterWildcard" xml:space="preserve">
+    <value>Filter Wildcard</value>
+  </data>
+  <data name="SearchTypeAlbum" xml:space="preserve">
+    <value>album</value>
+    <comment>Argument supported by 'Search for Item'::Types</comment>
+  </data>
+  <data name="SearchTypeArtist" xml:space="preserve">
+    <value>artist</value>
+    <comment>Argument supported by 'Search for Item'::Types</comment>
+  </data>
+  <data name="SearchTypePlaylist" xml:space="preserve">
+    <value>playlist</value>
+    <comment>Argument supported by 'Search for Item'::Types</comment>
+  </data>
+  <data name="SearchTypeTrack" xml:space="preserve">
+    <value>track</value>
+    <comment>Argument supported by 'Search for Item'::Types</comment>
+  </data>
+  <data name="SearchTypeShow" xml:space="preserve">
+    <value>show</value>
+    <comment>Argument supported by 'Search for Item'::Types</comment>
+  </data>
+  <data name="SearchTypeEpisode" xml:space="preserve">
+    <value>episode</value>
+    <comment>Argument supported by 'Search for Item'::Types</comment>
+  </data>
+  <data name="SearchTypeAudiobook" xml:space="preserve">
+    <value>audiobook</value>
+    <comment>Argument supported by 'Search for Item'::Types</comment>
+  </data>
+  <data name="ExtensionSettingClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="EmptyFilteredResultsTitle" xml:space="preserve">
+    <value>No item found (filter applied).</value>
+  </data>
 </root>


### PR DESCRIPTION
# Feature
Adds the ability to filter results by the following search types, returning only items of the types selected: 

- Album
- Artist
- Playlist
- Track

![Command Palette Filter](https://github.com/user-attachments/assets/9c705c91-a584-4840-a647-c0b98b1d2f0c)

## Explanation

This leverages the 'type' parameter in the ['Search For Item' endpoint](https://developer.spotify.com/documentation/web-api/reference/search).

This is implemented using the `System.Text.RegularExpressions` library to match `{wildcard}(album|artist|playlist|track)` within the search term, adjust the `SearchRequest.Types` parameter, and then continue with the match removed from the search term. Multiple filters may be applied.

The filter wildcard (default '/') can be changed in the Extension Settings. There are no restrictions in place at the moment - any string value is accepted.

The search terms support localisation, however I have only added the default English strings so the implementation is somewhat theoretical. A localised filter expression (i.e. `{wildcard}{'album', but in another language}` is remapped to English for the API call.

## Known Issues

- Changing the wildcard setting sometimes crashes the Command Palette once when selecting the extension.
  - Unfortunately I haven't been able to consistently reproduce this.
- Changing the wildcard setting is not properly displayed in settings until the extension is reloaded.
  1. I change the filter wildcard setting from '/' to '!' and close the settings window.
  2. I can now search specifically for albums using "!album {search}"
  3. In the extension settings window, it still shows '/' for the wildcard.
  4. After reloading the extension using 'reload', it shows '!'.
- New localised terms only have English values.

My assumption is the two issues are related, but the solution is currently beyond me.

## Potential Improvements

- I hoped to update the search bar dynamically to emphasise a recognised filter (such as presenting it in a different colour) but as far as I can tell editing the formatting of the search bar is not possible at the moment.
- 'Field' filters are supported by the endpoint, but as they include more complex logic (such as year ranges) it risked overcomplicating things for now.
- Additional commands such as only returning 'saved' items, or displaying details about the current track.
---
This is my first time contributing to a project and I have about as much experience with C#, so I apologise if anything isn't up to scratch! Please let me know and I'll try to make any changes required.
